### PR TITLE
Routing algo improvements

### DIFF
--- a/cmd/simulator/main.go
+++ b/cmd/simulator/main.go
@@ -132,10 +132,10 @@ func simulationV2() {
 	log.Println()
 	log.Println()
 
-	netw.Leave(nodeC.GetID())
-	log.Println()
-	log.Println()
+	netw.Leave(nodeD.GetID())
 	time.Sleep(5 * time.Second)
+	log.Println()
+	log.Println()
 
 	// Have to send message twice as first time is used to discover route -> to be fixed
 	// log.Println("NodeA -> NodeD: sending data!")
@@ -147,8 +147,8 @@ func simulationV2() {
 	log.Println("Shutting down.")
 	netw.Leave(nodeA.GetID())
 	netw.Leave(nodeB.GetID())
-	// netw.Leave(nodeC.GetID())
-	netw.Leave(nodeD.GetID())
+	netw.Leave(nodeC.GetID())
+	// netw.Leave(nodeD.GetID())
 	time.Sleep(1 * time.Second)
 
 	// TODO: This test case pases because the final node is not expected to ack the message -> to be fixed

--- a/cmd/simulator/main.go
+++ b/cmd/simulator/main.go
@@ -132,7 +132,9 @@ func simulationV2() {
 	log.Println()
 	log.Println()
 
-	netw.Leave(nodeD.GetID())
+	netw.Leave(nodeC.GetID())
+	log.Println()
+	log.Println()
 	time.Sleep(5 * time.Second)
 
 	// Have to send message twice as first time is used to discover route -> to be fixed
@@ -140,13 +142,13 @@ func simulationV2() {
 	nodeA.SendData(netw, nodeD.GetID(), "Hello from A to D")
 
 	// Let the route discovery / data forwarding happen
-	time.Sleep(30 * time.Second)
+	time.Sleep(20 * time.Second)
 
 	log.Println("Shutting down.")
 	netw.Leave(nodeA.GetID())
 	netw.Leave(nodeB.GetID())
-	netw.Leave(nodeC.GetID())
-	// netw.Leave(nodeD.GetID())
+	// netw.Leave(nodeC.GetID())
+	netw.Leave(nodeD.GetID())
 	time.Sleep(1 * time.Second)
 
 	// TODO: This test case pases because the final node is not expected to ack the message -> to be fixed

--- a/cmd/simulator/main.go
+++ b/cmd/simulator/main.go
@@ -14,35 +14,34 @@ import (
 // Main Simulation
 // ----------------------------------------------------------------------------
 func main() {
-		// Create logs directory if it doesn't exist
-		if err := os.MkdirAll("logs", 0755); err != nil {
-			log.Fatalf("Failed to create logs directory: %v", err)
-		}
-	
-		// Create log file with timestamp in name
-		timestamp := time.Now().Format("2006-01-02_15-04-05")
-		logFile, err := os.OpenFile("logs/log_"+timestamp+".log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
-		if err != nil {
-			log.Fatalf("Failed to open log file: %v", err)
-		}
-		defer logFile.Close()
-	
-		// Create a MultiWriter to write to both the log file and stdout
-		multiWriter := io.MultiWriter(os.Stdout, logFile)
-	
-		// Set log output to multiWriter
-		log.SetOutput(multiWriter)
-	
-		
-		// log.SetFlags(log.LstdFlags | log.Lshortfile)
-		log.SetFlags(0)
-	
-		// Log start of simulation
-		log.Println("Starting simulation...")
+	// Create logs directory if it doesn't exist
+	if err := os.MkdirAll("logs", 0755); err != nil {
+		log.Fatalf("Failed to create logs directory: %v", err)
+	}
+
+	// Create log file with timestamp in name
+	timestamp := time.Now().Format("2006-01-02_15-04-05")
+	logFile, err := os.OpenFile("logs/log_"+timestamp+".log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	if err != nil {
+		log.Fatalf("Failed to open log file: %v", err)
+	}
+	defer logFile.Close()
+
+	// Create a MultiWriter to write to both the log file and stdout
+	multiWriter := io.MultiWriter(os.Stdout, logFile)
+
+	// Set log output to multiWriter
+	log.SetOutput(multiWriter)
+
+	// log.SetFlags(log.LstdFlags | log.Lshortfile)
+	log.SetFlags(0)
+
+	// Log start of simulation
+	log.Println("Starting simulation...")
+
 	simulationV2()
 
 }
-
 
 func simulationV1() {
 	//Create the network and start it
@@ -121,8 +120,6 @@ func simulationV2() {
 	// nodeB.SendData(netw, nodeD.GetID(), "Hello from B to D")
 	// time.Sleep(10 * time.Second)
 
-
-	
 	log.Println()
 	log.Println()
 	log.Println()
@@ -130,14 +127,14 @@ func simulationV2() {
 	// Now let's test multi-hop. A wants to send data to C
 	log.Println("NodeA -> NodeD: sending data! -> setting up route")
 	nodeA.SendData(netw, nodeD.GetID(), "Hello from A to D")
-	
+
 	time.Sleep(10 * time.Second)
 	log.Println()
 	log.Println()
 
 	// Have to send message twice as first time is used to discover route -> to be fixed
-	log.Println("NodeA -> NodeD: sending data!")
-	nodeA.SendData(netw, nodeD.GetID(), "Hello from A to D")
+	// log.Println("NodeA -> NodeD: sending data!")
+	// nodeA.SendData(netw, nodeD.GetID(), "Hello from A to D")
 
 	// Let the route discovery / data forwarding happen
 	time.Sleep(10 * time.Second)
@@ -148,4 +145,40 @@ func simulationV2() {
 	netw.Leave(nodeC.GetID())
 	netw.Leave(nodeD.GetID())
 	time.Sleep(1 * time.Second)
+}
+
+func simulationV3() {
+	netw := network.NewNetwork()
+	go netw.Run()
+
+	nodeA := node.NewNode(0, 0)
+	nodeB := node.NewNode(0, 1000)
+	nodeC := node.NewNode(0, 2000)
+	nodeD := node.NewNode(0, 3000)
+
+	netw.Join(nodeA)
+	netw.Join(nodeB)
+	netw.Join(nodeC)
+	netw.Join(nodeD)
+
+	// Sleep so they can broadcast HELLO and find each other
+	time.Sleep(10 * time.Second)
+
+	netw.Leave(nodeA.GetID())
+
+	time.Sleep(4 * time.Second)
+
+	log.Println()
+	log.Println("Node A ID is: ", nodeA.GetID())
+	log.Println()
+
+
+
+	nodeB.SendData(netw, nodeA.GetID(), "Hello from B to A")
+
+	time.Sleep(10 * time.Second)
+
+	netw.Leave(nodeB.GetID())
+	netw.Leave(nodeC.GetID())
+	netw.Leave(nodeD.GetID())
 }

--- a/cmd/simulator/main.go
+++ b/cmd/simulator/main.go
@@ -128,11 +128,11 @@ func simulationV2() {
 	log.Println("NodeA -> NodeD: sending data! -> setting up route")
 	nodeA.SendData(netw, nodeD.GetID(), "Hello from A to D")
 
-	time.Sleep(30 * time.Second)
+	time.Sleep(10 * time.Second)
 	log.Println()
 	log.Println()
 
-	netw.Leave(nodeC.GetID())
+	netw.Leave(nodeD.GetID())
 	time.Sleep(5 * time.Second)
 
 	// Have to send message twice as first time is used to discover route -> to be fixed
@@ -145,9 +145,11 @@ func simulationV2() {
 	log.Println("Shutting down.")
 	netw.Leave(nodeA.GetID())
 	netw.Leave(nodeB.GetID())
-	// netw.Leave(nodeC.GetID())
-	netw.Leave(nodeD.GetID())
+	netw.Leave(nodeC.GetID())
+	// netw.Leave(nodeD.GetID())
 	time.Sleep(1 * time.Second)
+
+	// TODO: This test case pases because the final node is not expected to ack the message -> to be fixed
 }
 
 func simulationV3() {

--- a/cmd/simulator/main.go
+++ b/cmd/simulator/main.go
@@ -128,21 +128,24 @@ func simulationV2() {
 	log.Println("NodeA -> NodeD: sending data! -> setting up route")
 	nodeA.SendData(netw, nodeD.GetID(), "Hello from A to D")
 
-	time.Sleep(10 * time.Second)
+	time.Sleep(30 * time.Second)
 	log.Println()
 	log.Println()
+
+	netw.Leave(nodeC.GetID())
+	time.Sleep(5 * time.Second)
 
 	// Have to send message twice as first time is used to discover route -> to be fixed
 	// log.Println("NodeA -> NodeD: sending data!")
-	// nodeA.SendData(netw, nodeD.GetID(), "Hello from A to D")
+	nodeA.SendData(netw, nodeD.GetID(), "Hello from A to D")
 
 	// Let the route discovery / data forwarding happen
-	time.Sleep(10 * time.Second)
+	time.Sleep(30 * time.Second)
 
 	log.Println("Shutting down.")
 	netw.Leave(nodeA.GetID())
 	netw.Leave(nodeB.GetID())
-	netw.Leave(nodeC.GetID())
+	// netw.Leave(nodeC.GetID())
 	netw.Leave(nodeD.GetID())
 	time.Sleep(1 * time.Second)
 }

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -12,18 +12,21 @@ const (
 	MsgHello    MessageType = "HELLO"
 	MsgHelloAck MessageType = "HELLO_ACK"
 	MsgData     MessageType = "DATA"
+	DataAck	    MessageType = "DATA_ACK"
 
 	BroadcastID = "00000000-0000-0000-0000-000000000000"
 
 	// Routing messages
 	MsgRREQ MessageType = "RREQ"
     MsgRREP MessageType = "RREP"
+	MsgRERR MessageType = "RERR"
 )
 
 // Message is a simple struct implementing IMessage.
 type Message struct {
 	Type    MessageType
 	From    uuid.UUID
+	Origin    uuid.UUID
 	To      uuid.UUID
 	Dest	uuid.UUID
 	ID      string
@@ -59,3 +62,9 @@ func (m *Message) GetPayload() string {
 func (m *Message) GetDest() uuid.UUID {
 	return m.Dest
 }
+
+// GetOrigin returns the origin ID.
+func (m *Message) GetOrigin() uuid.UUID {
+	return m.Origin
+}
+

--- a/internal/message/messageInterface.go
+++ b/internal/message/messageInterface.go
@@ -9,4 +9,5 @@ type IMessage interface {
 	GetID() string
 	GetPayload() string
 	GetDest() uuid.UUID
+	GetOrigin() uuid.UUID
 }

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -66,7 +66,7 @@ func (net *networkImpl) BroadcastMessage(msg message.IMessage, sender mesh.INode
 		if net.IsInRange(sender, nd) {
 			ndChan := net.getNodeChannel(nd)
 			ndChan <- msg
-			log.Printf("[Network] Node %q is IN of range for broadcast.\n", id)
+			log.Printf("[Network] Node %q is IN range for broadcast.\n", id)
 		} else {
 			log.Printf("[Network] Node %q is OUT of range for broadcast.\n", id)
 		}
@@ -99,7 +99,7 @@ func (net *networkImpl) addNode(n mesh.INode) {
 	net.nodes[n.GetID()] = n
 	net.mu.Unlock()
 
-	
+
 
 	log.Printf("[sim] Node %s: joining network.\n", n.GetID())
 	go n.Run(net)

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -87,7 +87,7 @@ func (net *networkImpl) UnicastMessage(msg message.IMessage, sender mesh.INode) 
 				sender.GetID(), to)
 		}
 	} else {
-		log.Printf("[Network] Node %q tried to send to unknown node %q.\n",
+		log.Printf("[Network] Node %q tried to send to unknown node %q. Continuing anyway...\n",
 			sender.GetID(), to)
 	}
 }

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -66,8 +66,9 @@ func (net *networkImpl) BroadcastMessage(msg message.IMessage, sender mesh.INode
 		if net.IsInRange(sender, nd) {
 			ndChan := net.getNodeChannel(nd)
 			ndChan <- msg
+			log.Printf("[Network] Node %q is IN of range for broadcast.\n", id)
 		} else {
-			log.Printf("[Network] Node %q is out of range for broadcast.\n", id)
+			log.Printf("[Network] Node %q is OUT of range for broadcast.\n", id)
 		}
 	}
 }
@@ -97,6 +98,8 @@ func (net *networkImpl) addNode(n mesh.INode) {
 	net.mu.Lock()
 	net.nodes[n.GetID()] = n
 	net.mu.Unlock()
+
+	
 
 	log.Printf("[sim] Node %s: joining network.\n", n.GetID())
 	go n.Run(net)

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -120,7 +120,7 @@ func (n *nodeImpl) HandleMessage(net mesh.INetwork, msg message.IMessage) {
 		n.neighbors[msg.GetFrom()] = true
 		n.router.AddDirectNeighbor(n.id, msg.GetFrom())
 		n.muNeighbors.Unlock()
-	case message.MsgData, message.MsgRREP, message.MsgRREQ, message.MsgRERR:
+	case message.MsgData, message.MsgRREP, message.MsgRREQ, message.MsgRERR, message.DataAck:
 		n.router.HandleMessage(net, n, msg)
 	default:
 		log.Printf("Node %s: unknown message type from %s\n", n.id, msg.GetFrom())

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -52,11 +52,18 @@ func (n *nodeImpl) Run(net mesh.INetwork) {
 	log.Printf("Node %s: started.\n", n.id)
 	defer log.Printf("Node %s: stopped.\n", n.id)
 
+	if aodv, ok := n.router.(*routing.AODVRouter); ok {
+		aodv.StartPendingTxChecker(net, n)
+	}
+
 	for {
 		select {
 		case msg := <-n.messages:
 			n.HandleMessage(net, msg)
 		case <-n.quit:
+			if aodv, ok := n.router.(*routing.AODVRouter); ok {
+				aodv.StopPendingTxChecker()
+			}
 			return
 		}
 	}
@@ -113,11 +120,7 @@ func (n *nodeImpl) HandleMessage(net mesh.INetwork, msg message.IMessage) {
 		n.neighbors[msg.GetFrom()] = true
 		n.router.AddDirectNeighbor(n.id, msg.GetFrom())
 		n.muNeighbors.Unlock()
-	case message.MsgData:
-		// log.Printf("Node %s: received DATA from %s, payload=%q\n",
-		// n.id, msg.GetFrom(), msg.GetPayload())
-		n.router.HandleMessage(net, n, msg)
-	case message.MsgRREQ, message.MsgRREP:
+	case message.MsgData, message.MsgRREP, message.MsgRREQ, message.MsgRERR:
 		n.router.HandleMessage(net, n, msg)
 	default:
 		log.Printf("Node %s: unknown message type from %s\n", n.id, msg.GetFrom())

--- a/internal/routing/aodv.go
+++ b/internal/routing/aodv.go
@@ -33,28 +33,103 @@ type RouteEntry struct {
 	HopCount    int
 }
 
+type RERRControl struct {
+	BrokenNode uuid.UUID
+	MessageDest 	 uuid.UUID
+	MessageId string
+	MessageSource uuid.UUID
+}
+
+// Used to store transactions that are pending ACKs
+type PendingTx struct {
+    MsgID       string
+    Dest        uuid.UUID // destination of the data
+    PotentialBrokenNode     uuid.UUID // (the broken node)
+	Origin 	    uuid.UUID // original source of the data
+    ExpiryTime  time.Time 
+}
+
 // AODVRouter is a per-node router
 type AODVRouter struct {
 	ownerID    uuid.UUID
 	routeTable map[uuid.UUID]*RouteEntry // key = destination ID
 	seenMsgIDs map[string]bool           // deduplicate RREQ/RREP
 	dataQueue map[uuid.UUID][]string 	// queue of data to send after route is established
+	pendingTxs map[string]PendingTx
+	quitChan   chan struct{}
 }
 
 // NewAODVRouter constructs a router for a specific node
 func NewAODVRouter(ownerID uuid.UUID) *AODVRouter {
 	return &AODVRouter{
 		ownerID:    ownerID,
-		routeTable: make(map[uuid.UUID]*RouteEntry), // TODO: implement a timeout for routes
+		routeTable: make(map[uuid.UUID]*RouteEntry), // TODO: implement a timeout for routes 
 		seenMsgIDs: make(map[string]bool),
 		dataQueue: make(map[uuid.UUID][]string),
+		pendingTxs: make(map[string]PendingTx),
+		quitChan:   make(chan struct{}),
 	}
 }
+
+// ------------------------------------------------------------
+// runPendingTxChecker periodically checks pendingTxs for expired entries
+// If expired, we assume we never overheard the forward => route is broken
+
+func (r *AODVRouter) StartPendingTxChecker(net mesh.INetwork, node mesh.INode) {
+	go r.runPendingTxChecker(net, node)
+}
+
+func (r *AODVRouter) runPendingTxChecker(net mesh.INetwork, node mesh.INode) {
+    ticker := time.NewTicker(1 * time.Second) // check every 1s
+    defer ticker.Stop()
+
+    for {
+        select {
+        case <-r.quitChan:
+            return
+        case <-ticker.C:
+            now := time.Now()
+            for msgID, tx := range r.pendingTxs {
+                if now.After(tx.ExpiryTime) {
+                    log.Printf("[Timeout] Node %s: pendingTx expired for msgID=%s => route to %s is considered broken",
+                        r.ownerID, msgID, tx.Dest)
+
+                    // Remove from pendingTxs
+                    delete(r.pendingTxs, msgID)
+
+                    // Optionally remove route
+					log.Printf("Node %s: removing route to %s due to timeout", r.ownerID, tx.Dest)
+					delete(r.routeTable, tx.PotentialBrokenNode)
+					// TODO: more items to delete 
+					// - ANY route that nextHop is the broken node
+
+                    route, found := r.routeTable[tx.Origin]
+                    if found {
+
+                        // If we have net & node references, we can send RERR
+                        if net != nil && node != nil {
+                            // We'll craft a minimal sendRERR. We can guess the original source as r.ownerID,
+                            // or store it in PendingTx if you want the actual source
+                            r.sendRERR(net, node, route.NextHop, tx.Dest, tx.PotentialBrokenNode, msgID, tx.Origin)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Stop the pendingTxChecker
+func (r *AODVRouter) StopPendingTxChecker() {
+    close(r.quitChan)
+}
+
+
 
 // -- IRouter methods --
 
 func (r *AODVRouter) SendData(net mesh.INetwork, sender mesh.INode, destID uuid.UUID, payload string) {
-	// 1. Check if we already have a route
+	// Check if we already have a route
 	entry, hasRoute := r.routeTable[destID]
 	if !hasRoute {
 		// Initiate RREQ
@@ -64,32 +139,62 @@ func (r *AODVRouter) SendData(net mesh.INetwork, sender mesh.INode, destID uuid.
 		return
 	}
 
-	// 2. We have a route -> unicast data to NextHop
+	// We have a route -> unicast data to NextHop
+	msgID:= fmt.Sprintf("data-%s-%s-%d", r.ownerID, destID, time.Now().UnixNano())
 	nextHop := entry.NextHop
 	dataMsg := &message.Message{
 		Type:    message.MsgData,
 		From:    r.ownerID,
+		Origin:  r.ownerID,
 		To:      nextHop, //Todo: this could be nextHop
 		Dest:    destID,
-		ID:      fmt.Sprintf("data-%s-%s-%d", r.ownerID, destID, time.Now().UnixNano()),
+		ID:      msgID,
 		Payload: payload,
 	}
 
 	log.Printf("[sim] Node %s (router) -> forwarding data to %s via %s\n", r.ownerID, destID, nextHop)
-	net.UnicastMessage(dataMsg, sender)
+	net.BroadcastMessage(dataMsg, sender)
+
+	expire := time.Now().Add(3 * time.Second) // e.g. 3s
+	r.pendingTxs[msgID] = PendingTx{
+		MsgID: msgID,
+		Dest:  destID,
+		PotentialBrokenNode: nextHop,
+		Origin: r.ownerID,
+		ExpiryTime: expire,
+	}
 }
 
 // HandleMessage is called when the node receives any message
+// TODO: repeated logic should be removed?????
 func (r *AODVRouter) HandleMessage(net mesh.INetwork, node mesh.INode, msg message.IMessage) {
 	switch msg.GetType() {
 	case message.MsgRREQ:
+		// All nodes who recieve should handle
 		r.handleRREQ(net, node, msg)
 	case message.MsgRREP:
-		r.handleRREP(net, node, msg)
+		// Only the intended recipient should handle
+		if msg.GetTo() == r.ownerID {
+			r.handleRREP(net, node, msg)
+		}
+	case message.MsgRERR:
+		// All nodes who recieve should handle
+		r.handleRERR(net, node, msg)
 	case message.MsgData:
-		r.handleDataForward(net, node, msg)
+		// Overhearing logic for implicit ACKs
+		if pt, ok := r.pendingTxs[msg.GetID()]; ok && pt.PotentialBrokenNode == msg.GetFrom() {
+            // ack
+            log.Printf("{Implicit ACK}  Node %s: overheard forward from %s => implicit ack for msgID=%s", 
+                       r.ownerID, msg.GetFrom(), msg.GetID())
+            delete(r.pendingTxs, msg.GetID())
+        }
+		// Only the intended recipient should handle
+		if msg.GetTo() == r.ownerID {
+			r.handleDataForward(net, node, msg)
+		}
 	default:
 		// not a routing message
+		log.Printf("[sim] Node %s (router) -> received non-routing message: %s\n", r.ownerID, msg.GetType())
 	}
 }
 
@@ -143,6 +248,7 @@ func (r *AODVRouter) initiateRREQ(net mesh.INetwork, sender mesh.INode, destID u
 	net.BroadcastMessage(rreqMsg, sender)
 }
 
+// Every Node needs to handle this 
 func (r *AODVRouter) handleRREQ(net mesh.INetwork, node mesh.INode, msg message.IMessage) {
 	if r.seenMsgIDs[msg.GetID()] {
 		log.Printf("Node %s: ignoring duplicate RREQ.\n", r.ownerID)
@@ -207,9 +313,10 @@ func (r *AODVRouter) sendRREP(net mesh.INetwork, node mesh.INode, source, destin
 		Payload: string(bytes),
 	}
 	log.Printf("[sim] [RREP] Node %s: sending RREP to %s via %s current hop count: %d\n", r.ownerID, source, reverseRoute.NextHop, hopCount)
-	net.UnicastMessage(rrepMsg, node)
+	net.BroadcastMessage(rrepMsg, node)
 }
 
+// Only node specified in the RREP message should handle this
 func (r *AODVRouter) handleRREP(net mesh.INetwork, node mesh.INode, msg message.IMessage) {
 	if r.seenMsgIDs[msg.GetID()] {
 		return
@@ -252,7 +359,95 @@ func (r *AODVRouter) handleRREP(net mesh.INetwork, node mesh.INode, msg message.
 		Payload: string(bytes),
 	}
 	log.Printf("[RREP FORWARD] Node %s: forwarding RREP to %s via %s\n", r.ownerID, ctrl.Destination, reverseRoute.NextHop)
-	net.UnicastMessage(fwdRrep, node)
+	net.BroadcastMessage(fwdRrep, node)
+}
+
+func (r *AODVRouter) sendRERR(net mesh.INetwork, node mesh.INode, to uuid.UUID, dataDest uuid.UUID, brokenNode uuid.UUID, messageId string, messageSource uuid.UUID) {
+    rerr := RERRControl{
+        BrokenNode: brokenNode,
+        MessageDest:       dataDest,
+		MessageId: messageId,
+		MessageSource: messageSource,
+    }
+    j, _ := json.Marshal(rerr)
+    msgID := fmt.Sprintf("rerr-%s-%d", r.ownerID, time.Now().UnixNano())
+    r.seenMsgIDs[msgID] = true
+    rerrMsg := &message.Message{
+        Type:    message.MsgRERR,
+        From:    r.ownerID,
+        To:      to, // unicast to upstream node
+        ID:      msgID,
+        Payload: string(j),
+    }
+    log.Printf("[sim] Node %s: sending RERR to %s about broken route for %s.\n", r.ownerID, to, dataDest)
+    net.BroadcastMessage(rerrMsg, node)
+}
+
+// Everyone who receives RERR should handle this (only intended recipient should forward to source) (source should not forward)
+func (r *AODVRouter) handleRERR(net mesh.INetwork, node mesh.INode, msg message.IMessage) {
+    if r.seenMsgIDs[msg.GetID()] {
+        return
+    }
+    r.seenMsgIDs[msg.GetID()] = true
+
+    var rc RERRControl
+    if err := json.Unmarshal([]byte(msg.GetPayload()), &rc); err != nil {
+        return
+    }
+
+    log.Printf("[sim] Node %s: received RERR => broken node: %s for dest %s\n", r.ownerID, rc.BrokenNode, rc.MessageDest)
+
+    // remove the route to rc.Dest if the nextHop is rc.BrokenNode
+    entry, ok := r.routeTable[rc.MessageDest]
+    if ok && entry.NextHop == msg.GetFrom(){
+        log.Printf("Node %s: removing route to %s because nextHop is broken.\n", r.ownerID, rc.MessageDest)
+        delete(r.routeTable, rc.MessageDest) // still incorrect 
+		// TODO: more items to delete
+		// - ANY route that nextHop is the broken node
+		// - Any route to the broken node needs to be removed
+
+    }
+
+	// Check if node is the intended target
+	if r.ownerID != msg.GetTo() {
+		log.Printf("{RERR} Node %s: received RERR not intended for me.\n", r.ownerID)
+		return
+	}
+
+	if r.ownerID == rc.MessageSource {
+		log.Printf("{RERR} Node %s: received RERR for my own message, stopping here.\n", r.ownerID)
+		return
+	}
+
+
+	entry, hasRoute := r.routeTable[rc.MessageSource]
+	if !hasRoute {
+		log.Printf("[sim] {RERR FAIL} Node %s: no route to forward RERR destined for %s.\n", r.ownerID, rc.MessageSource)
+		return
+	}
+
+	// If we have a route to the source of the message, we can forward the RERR
+	nexthop := entry.NextHop
+	r.sendRERR(net, node, nexthop, rc.MessageDest, rc.BrokenNode, rc.MessageId, rc.MessageSource)
+
+	// Message source is in the payload, use existing route to forward RERR
+	// This is a simplification, in real AODV we might need to store the "previous hop" for each route
+
+
+
+    // if I'm not the source, I forward RERR upstream
+    // how do we know who is the source? We might store it or check who gave me data originally
+    // For now, let's just forward to the route of rc.Dest's Source if we know it
+    // or we can store the msg.GetFrom() as the "previous hop" and forward there
+    // If I have a route to the original source of the data, we can forward
+    // This part can vary depending on how you track the "source" of data
+
+    // (Simplified) If we do want to forward RERR, we need to know the "previous hop".
+    // We might just do nothing if we don't store that. 
+    // Real AODV would keep track of all active flows or have a route to the source.
+
+    // if we are the original source, we might re-initiate RREQ. 
+    // But for simplicity, let's stop here.
 }
 
 // handleDataForward attempts to forward data if the node isn't the final dest
@@ -260,19 +455,24 @@ func (r *AODVRouter) handleDataForward(net mesh.INetwork, node mesh.INode, msg m
 	// If I'm the final destination, do nothing -> the node can "deliver" it
 	if msg.GetDest() == r.ownerID {
 		log.Printf("[sim] Node %s: DATA arrived. Payload = %q\n", r.ownerID, msg.GetPayload())
+		// Send an ACK back to the sender
+		// r.sendDataAck(net, node, msg.GetFrom())
 		return
 	}
 
 	//TODO: Could this call SendData?
 
 	// Otherwise, I should forward it if I have a route
-	originID := msg.GetFrom()
+	
 	dest := msg.GetDest()
 	route, ok := r.routeTable[dest]
 	if !ok {
+		// This is in theory an unlikely case because the origin node should have initiated RREQ
 		// No route, we might trigger route discovery or drop
 		log.Printf("[sim] Node %s: no route to forward DATA destined for %s.\n", r.ownerID, dest)
 		// Optionally: r.initiateRREQ(...)
+		// no route therefore, we need ot send RERR 
+		r.sendRERR(net, node, msg.GetFrom(), dest, r.ownerID, msg.GetID(), msg.GetOrigin())
 		return
 	}
 
@@ -281,12 +481,44 @@ func (r *AODVRouter) handleDataForward(net mesh.INetwork, node mesh.INode, msg m
 		Type:    message.MsgData,
 		From:    r.ownerID, // I'm forwarding
 		To:      route.NextHop,
+		Origin:  msg.GetOrigin(),
 		Dest:    dest,
 		ID:      msg.GetID(), // keep same ID or generate new
 		Payload: msg.GetPayload(),
 	}
-	log.Printf("[sim] Node %s: forwarding DATA from %s to %s via %s\n", r.ownerID, originID, dest, route.NextHop)
-	net.UnicastMessage(fwdMsg, node)
+	log.Printf("[sim] Node %s: forwarding DATA from %s to %s via %s\n", r.ownerID, msg.GetFrom(), dest, route.NextHop)
+	net.BroadcastMessage(fwdMsg, node)
+
+	// Implicit ACK: if the next hop is the intended recipient, we can assume the data was received
+	if route.NextHop == dest {
+		// log.Printf("{Implicit ACK} Node %s: overheard forward from %s => implicit ack for msgID=%s", r.ownerID, originID, msg.GetID())
+		// TODO: need to wait for an explicit ACK in the future
+		return
+	}
+
+	// If the next hop is not the destination, we need to track the transaction by overhearing it
+	expire := time.Now().Add(3 * time.Second) // e.g. 3s
+	r.pendingTxs[msg.GetID()] = PendingTx{
+		MsgID: msg.GetID(),
+		Dest:  dest,
+		PotentialBrokenNode: route.NextHop,
+		Origin: msg.GetOrigin(),
+		ExpiryTime: expire,
+	}
+
+}
+
+// send ack for data packets
+func (r *AODVRouter) sendDataAck(net mesh.INetwork, node mesh.INode, dest uuid.UUID) {
+	ackMsg := &message.Message{
+		Type:    message.DataAck,
+		From:    r.ownerID,
+		To:      dest,
+		ID:      fmt.Sprintf("ack-%s-%s-%d", r.ownerID, dest, time.Now().UnixNano()),
+		Payload: "ACK",
+	}
+	log.Printf("[sim] Node %s: sending DATA_ACK to %s\n", r.ownerID, dest)
+	net.BroadcastMessage(ackMsg, node)
 }
 
 // maybeAddRoute updates route if shorter

--- a/internal/routing/aodv.go
+++ b/internal/routing/aodv.go
@@ -12,6 +12,13 @@ import (
 	"github.com/google/uuid"
 )
 
+/*
+TODO:
+- Implement a timeout for routes
+-Implement an ack for data packets (check what meshtastic does)
+-Implement RERR (route error) messages when route is broken 
+*/
+
 // AODVControl is extra data for RREQ/RREP
 type AODVControl struct {
 	Source      uuid.UUID
@@ -38,7 +45,7 @@ type AODVRouter struct {
 func NewAODVRouter(ownerID uuid.UUID) *AODVRouter {
 	return &AODVRouter{
 		ownerID:    ownerID,
-		routeTable: make(map[uuid.UUID]*RouteEntry),
+		routeTable: make(map[uuid.UUID]*RouteEntry), // TODO: implement a timeout for routes
 		seenMsgIDs: make(map[string]bool),
 		dataQueue: make(map[uuid.UUID][]string),
 	}

--- a/internal/routing/aodv.go
+++ b/internal/routing/aodv.go
@@ -49,7 +49,7 @@ func (r *AODVRouter) SendData(net mesh.INetwork, sender mesh.INode, destID uuid.
 	entry, hasRoute := r.routeTable[destID]
 	if !hasRoute {
 		// Initiate RREQ
-		log.Printf("Node %s (router) -> no route for %s, initiating RREQ.\n", r.ownerID, destID)
+		log.Printf("[sim] Node %s (router) -> no route for %s, initiating RREQ.\n", r.ownerID, destID)
 		r.initiateRREQ(net, sender, destID)
 		return
 	}
@@ -129,7 +129,7 @@ func (r *AODVRouter) initiateRREQ(net mesh.INetwork, sender mesh.INode, destID u
 		ID:      broadcastID,
 		Payload: string(bytes),
 	}
-	log.Printf("[RREQ init] Node %s (router) -> initiating RREQ for %s (hop count %d)\n", r.ownerID, destID, 0)
+	log.Printf("[sim] [RREQ init] Node %s (router) -> initiating RREQ for %s (hop count %d)\n", r.ownerID, destID, 0)
 	net.BroadcastMessage(rreqMsg, sender)
 }
 
@@ -150,7 +150,7 @@ func (r *AODVRouter) handleRREQ(net mesh.INetwork, node mesh.INode, msg message.
 
 	// if I'm the destination, send RREP
 	if r.ownerID == ctrl.Destination {
-		log.Printf("Node %s: RREQ arrived at destination.\n", r.ownerID)
+		log.Printf("[sim] Node %s: RREQ arrived at destination.\n", r.ownerID)
 		r.sendRREP(net, node, ctrl.Source, ctrl.Destination, 0) // Should this reset to 0 (yes)
 		return
 	}
@@ -171,7 +171,7 @@ func (r *AODVRouter) handleRREQ(net mesh.INetwork, node mesh.INode, msg message.
 		ID:      msg.GetID(),
 		Payload: string(newPayload),
 	}
-	log.Printf("[RREQ FORWARD] Node %s: forwarding RREQ for %s (hop count %d)\n", r.ownerID, ctrl.Destination, ctrl.HopCount)
+	log.Printf("[sim] [RREQ FORWARD] Node %s: forwarding RREQ for %s (hop count %d)\n", r.ownerID, ctrl.Destination, ctrl.HopCount)
 	net.BroadcastMessage(fwdMsg, node)
 }
 
@@ -196,7 +196,7 @@ func (r *AODVRouter) sendRREP(net mesh.INetwork, node mesh.INode, source, destin
 		ID:      fmt.Sprintf("rrep-%s-%s-%d", destination, source, time.Now().UnixNano()),
 		Payload: string(bytes),
 	}
-	log.Printf("[RREP] Node %s: sending RREP to %s via %s current hop count: %d\n", r.ownerID, source, reverseRoute.NextHop, hopCount)
+	log.Printf("[sim] [RREP] Node %s: sending RREP to %s via %s current hop count: %d\n", r.ownerID, source, reverseRoute.NextHop, hopCount)
 	net.UnicastMessage(rrepMsg, node)
 }
 

--- a/internal/routing/router_interface.go
+++ b/internal/routing/router_interface.go
@@ -18,4 +18,10 @@ type IRouter interface {
 
     // print out the routing table
     PrintRoutingTable()
+
+    // Start the router's Tx check go routine
+    StartPendingTxChecker(net mesh.INetwork, node mesh.INode)
+
+    // Stop the router's Tx check go routine
+    StopPendingTxChecker()
 }


### PR DESCRIPTION
This pull request introduces several enhancements and bug fixes to the simulator's networking functionality, including the addition of a new simulation version, updates to message handling, and improvements to the AODV routing protocol. The most important changes include the addition of a new simulation function, enhancements to message types and handling, and updates to the AODV routing protocol to handle route errors and acknowledgments.

### New Simulation Function:
* Added `simulationV3` function in `cmd/simulator/main.go` to test network behavior with node departures and message sending.

### Message Handling Enhancements:
* Added new message types `DataAck` and `MsgRERR` in `internal/message/message.go` to support data acknowledgment and route error handling.
* Implemented `GetOrigin` method in `internal/message/message.go` to retrieve the origin ID of a message.
* Updated `IMessage` interface in `internal/message/messageInterface.go` to include the `GetOrigin` method.

### AODV Routing Protocol Improvements:
* Introduced `PendingTx` and `RERRControl` structs in `internal/routing/aodv.go` to manage pending transactions and route errors.
* Added methods to start and stop a pending transaction checker in `AODVRouter` to handle expired transactions and send route error messages.
* Enhanced `AODVRouter` to handle `DataAck` and `MsgRERR` messages, and to send acknowledgments for received data.

### Logging and Debugging Improvements:
* Added logging for network operations such as broadcasting and unicasting messages, and node join events in `internal/network/network.go`. [[1]](diffhunk://#diff-0fc7f3150d0356714176307e25ee100b23f9b2060c2650a7ac5d94bac8827539R69-R71) [[2]](diffhunk://#diff-0fc7f3150d0356714176307e25ee100b23f9b2060c2650a7ac5d94bac8827539L90-R91)

### Code Clean-up:
* Removed commented-out code and unnecessary blank lines in `cmd/simulator/main.go` and other files to improve readability. [[1]](diffhunk://#diff-0fd69c9084b64b24341002a268074f6acb82671c5ca5cb3ac29717d82fb15778L36-L46) [[2]](diffhunk://#diff-0fd69c9084b64b24341002a268074f6acb82671c5ca5cb3ac29717d82fb15778L124-L125)