### PR TITLE
User to user messaging

### DIFF
--- a/internal/mesh/nodeInterface.go
+++ b/internal/mesh/nodeInterface.go
@@ -1,5 +1,7 @@
 package mesh
 
+
+
 type INode interface {
 	GetID() uint32
 	Run(net INetwork)

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -258,9 +258,6 @@ func (net *networkImpl) addNode(n mesh.INode) {
 
 	log.Printf("[sim] Node %d: joining network.\n", n.GetID())
 	go n.Run(net)
-
-	// Broadcast a HELLO so new node can discover neighbors.
-	n.SendBroadcastInfo(net)
 }
 
 // removeNode signals the node to stop and removes it from the map.

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -61,6 +61,9 @@ func (n *nodeImpl) Run(net mesh.INetwork) {
 
 	if aodv, ok := n.router.(*routing.AODVRouter); ok {
 		aodv.StartPendingTxChecker(net, n)
+		aodv.StartBroadcastTicker(net, n) 
+		
+		aodv.SendDiffBroadcastInfo(net, n)
 	}
 
 	for {
@@ -87,6 +90,7 @@ func (n *nodeImpl) Run(net mesh.INetwork) {
 // 	}
 // 	net.UnicastMessage(m, n)
 // }
+
 
 // SendData is a convenience method calling into the router
 func (n *nodeImpl) SendData(net mesh.INetwork, destID uint32, payload string) {
@@ -118,7 +122,8 @@ func (n *nodeImpl) SendBroadcastInfo(net mesh.INetwork) {
 	// 	Payload: fmt.Sprintf("Hello from %s", n.id),
 	// }
 	// net.BroadcastMessage(m, n)
-	n.router.SendBroadcastInfo(net, n)
+	// n.router.SendBroadcastInfo(net, n)
+	n.router.SendDiffBroadcastInfo(net, n);
 }
 
 // HandleMessage processes an incoming message.

--- a/internal/packet/diff_broadcast.go
+++ b/internal/packet/diff_broadcast.go
@@ -1,0 +1,86 @@
+package packet
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// ──────────────────────────────────────────────────────────────────────────────
+//  Diff-BroadcastInfo header  -- matches ESP32 firmware byte-for-byte
+// ──────────────────────────────────────────────────────────────────────────────
+type DiffBroadcastInfoHeader struct {
+	OriginNodeID uint32
+	NumAdded     uint16
+	NumRemoved   uint16
+}
+
+func (h *DiffBroadcastInfoHeader) Serialise() []byte {
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint32(buf[0:4], h.OriginNodeID)
+	binary.LittleEndian.PutUint16(buf[4:6], h.NumAdded)
+	binary.LittleEndian.PutUint16(buf[6:8], h.NumRemoved)
+	return buf
+}
+
+func (h *DiffBroadcastInfoHeader) Deserialise(buf []byte) error {
+	if len(buf) < 8 {
+		return fmt.Errorf("buffer too short for DiffBroadcastInfoHeader")
+	}
+	h.OriginNodeID = binary.LittleEndian.Uint32(buf[0:4])
+	h.NumAdded = binary.LittleEndian.Uint16(buf[4:6])
+	h.NumRemoved = binary.LittleEndian.Uint16(buf[6:8])
+	return nil
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+//  Packet builder
+// ──────────────────────────────────────────────────────────────────────────────
+func CreateDiffBroadcastInfoPacket(
+	srcID uint32,
+	originNodeID uint32,
+	added []uint32,
+	removed []uint32,
+	hopCount uint8,
+	packetID ...uint32,
+) ([]byte, uint32, error) {
+
+	pid := chooseID(packetID...)
+
+	bh := BaseHeader{
+		DestNodeID: BROADCAST_ADDR,
+		SrcNodeID:  srcID,
+		PacketID:   pid,
+		PacketType: PKT_BROADCAST_INFO,
+		HopCount:   hopCount,
+	}
+
+	dh := DiffBroadcastInfoHeader{
+		OriginNodeID: originNodeID,
+		NumAdded:     uint16(len(added)),
+		NumRemoved:   uint16(len(removed)),
+	}
+
+	bhBytes, _ := bh.SerialiseBaseHeader()
+	dhBytes := dh.Serialise()
+
+	total := len(bhBytes) + len(dhBytes) + 4*(len(added)+len(removed))
+	if total > MaxPacketSize {
+		return nil, 0, fmt.Errorf("DiffBroadcastInfo packet too big (%d B)", total)
+	}
+
+	pkt := make([]byte, total)
+	copy(pkt, bhBytes)
+	ofs := len(bhBytes)
+	copy(pkt[ofs:], dhBytes)
+	ofs += len(dhBytes)
+
+	for _, id := range added {
+		binary.LittleEndian.PutUint32(pkt[ofs:], id)
+		ofs += 4
+	}
+	for _, id := range removed {
+		binary.LittleEndian.PutUint32(pkt[ofs:], id)
+		ofs += 4
+	}
+	return pkt, pid, nil
+}

--- a/internal/packet/packet.go
+++ b/internal/packet/packet.go
@@ -25,7 +25,7 @@ const MaxPacketSize = 255
 
 const BROADCAST_ADDR uint32 = 0xFFFFFFFF
 
-const MAX_HOPS = 3
+const MAX_HOPS = 5
 
 type BaseHeader struct {
 	DestNodeID uint32 // destination of the hop not the route
@@ -86,9 +86,9 @@ type UREPHeader struct {
 
 // Different to RERR used when the node was found but the user was not at the node
 type UERRHeader struct {
-	UERRUserID       uint32 // id of user that is not found
-	UERRNodeID       uint32 // id of node that we thought the user was at
-	OriginNode       uint32
+	UserID       uint32 // id of user that is not found
+	NodeID       uint32 // id of node that we thought the user was at
+	OriginNodeID       uint32
 	OriginalPacketID uint32
 }
 
@@ -791,9 +791,9 @@ func CreateUERRPacket(
 		Reserved:   0,
 	}
 	h := UERRHeader{
-		UERRUserID:       uerrUserID,
-		UERRNodeID:       uerrNodeID,
-		OriginNode:       originNodeID,
+		UserID:       uerrUserID,
+		NodeID:       uerrNodeID,
+		OriginNodeID:       originNodeID,
 		OriginalPacketID: originalPacketID,
 	}
 
@@ -805,9 +805,9 @@ func CreateUERRPacket(
 
 	// serialize extended header (4×4 B)
 	hb := make([]byte, 16)
-	binary.LittleEndian.PutUint32(hb[0:4], h.UERRUserID)
-	binary.LittleEndian.PutUint32(hb[4:8], h.UERRNodeID)
-	binary.LittleEndian.PutUint32(hb[8:12], h.OriginNode)
+	binary.LittleEndian.PutUint32(hb[0:4], h.UserID)
+	binary.LittleEndian.PutUint32(hb[4:8], h.NodeID)
+	binary.LittleEndian.PutUint32(hb[8:12], h.OriginNodeID)
 	binary.LittleEndian.PutUint32(hb[12:16], h.OriginalPacketID)
 
 	// combine and return
@@ -838,9 +838,9 @@ func DeserialiseUERRPacket(
 	}
 	ofs := 16
 	h := UERRHeader{
-		UERRUserID:       binary.LittleEndian.Uint32(buf[ofs+0 : ofs+4]),
-		UERRNodeID:       binary.LittleEndian.Uint32(buf[ofs+4 : ofs+8]),
-		OriginNode:       binary.LittleEndian.Uint32(buf[ofs+8 : ofs+12]),
+		UserID:       binary.LittleEndian.Uint32(buf[ofs+0 : ofs+4]),
+		NodeID:       binary.LittleEndian.Uint32(buf[ofs+4 : ofs+8]),
+		OriginNodeID:       binary.LittleEndian.Uint32(buf[ofs+8 : ofs+12]),
 		OriginalPacketID: binary.LittleEndian.Uint32(buf[ofs+12 : ofs+16]),
 	}
 	return bh, h, nil

--- a/internal/packet/packet.go
+++ b/internal/packet/packet.go
@@ -351,7 +351,7 @@ func CreateRREQPacket(srcID, destID, orginNode uint32, numHops uint8, packetID .
 	return packetBuffer, pid, nil
 }
 
-func CreateRREPPacket(srcID, destRouteID, nextHopID, orginNode uint32, lifetime uint16, numHops uint8, packetID ...uint32) ([]byte, uint32, error) {
+func CreateRREPPacket(srcID, destRouteID, nextHopID, orginNode uint32, lifetime uint16, numHops, rrepNumHops uint8, packetID ...uint32) ([]byte, uint32, error) {
 
 	pid := chooseID(packetID...)
 
@@ -369,7 +369,7 @@ func CreateRREPPacket(srcID, destRouteID, nextHopID, orginNode uint32, lifetime 
 		OriginNodeID:   orginNode,   // node that wanted the route
 		RREPDestNodeID: destRouteID, // destination of the route
 		Lifetime:       lifetime,
-		NumHops:        numHops,
+		NumHops:        rrepNumHops,
 	}
 
 	bhBytes, err := bh.SerialiseBaseHeader()

--- a/internal/routing/aodv.go
+++ b/internal/routing/aodv.go
@@ -505,7 +505,7 @@ func (r *AODVRouter) sendRREP(net mesh.INetwork, node mesh.INode, destRREP, sour
 		log.Printf("Node %d: can't send RREP, no route to %d.\n", r.ownerID, sourceRREP)
 		return
 	}
-	rrepPacket, packetID, err := packet.CreateRREPPacket(r.ownerID, destRREP, reverseRoute.NextHop, sourceRREP, 0, 0)
+	rrepPacket, packetID, err := packet.CreateRREPPacket(r.ownerID, destRREP, reverseRoute.NextHop, sourceRREP, 0, 0, uint8(hopCount))
 	if err != nil {
 		return
 	}
@@ -527,7 +527,7 @@ func (r *AODVRouter) handleRREP(net mesh.INetwork, node mesh.INode, receivedPack
 	r.seenMsgIDs[bh.PacketID] = true
 
 	// Add forward route to ctrl.Source
-	r.maybeAddRoute(rreph.RREPDestNodeID, bh.SrcNodeID, int(bh.HopCount)+1)
+	r.maybeAddRoute(rreph.RREPDestNodeID, bh.SrcNodeID, int(rreph.NumHops)+1)
 	r.maybeAddRoute(bh.SrcNodeID, bh.SrcNodeID, 1)
 
 	// if I'm the original route requester, done
@@ -555,7 +555,7 @@ func (r *AODVRouter) handleRREP(net mesh.INetwork, node mesh.INode, receivedPack
 		return
 	}
 
-	rrepPacket, packetID, err := packet.CreateRREPPacket(r.ownerID, rreph.RREPDestNodeID, reverseRoute.Destination, rreph.OriginNodeID, 0, bh.HopCount+1, bh.PacketID)
+	rrepPacket, packetID, err := packet.CreateRREPPacket(r.ownerID, rreph.RREPDestNodeID, reverseRoute.Destination, rreph.OriginNodeID, 0, bh.HopCount+1, rreph.NumHops+1, bh.PacketID)
 	if err != nil {
 		return
 	}

--- a/internal/routing/router_interface.go
+++ b/internal/routing/router_interface.go
@@ -18,6 +18,7 @@ type IRouter interface {
 
 	// initial message to the network to broadcast a hello message
 	SendBroadcastInfo(net mesh.INetwork, node mesh.INode)
+	SendDiffBroadcastInfo(net mesh.INetwork, node mesh.INode);
 
 	// print out the routing table
 	PrintRoutingTable()


### PR DESCRIPTION
This pull request introduces a significant update to the mesh network's broadcast mechanism, transitioning from a full broadcast model to a differential broadcast model. Key changes include the addition of a new packet type for differential broadcasts, modifications to the AODV router to support this model, and updates to related packet structures and handling logic. Several refactorings and optimizations have also been made to improve code clarity and maintainability.

### Differential Broadcast Implementation:
* Introduced `DiffBroadcastInfoHeader` in `internal/packet/diff_broadcast.go` to encapsulate added and removed user IDs for differential broadcasts. This includes serialization and deserialization methods.
* Added `CreateDiffBroadcastInfoPacket` to construct differential broadcast packets, ensuring compliance with the maximum packet size.
* Implemented `SendDiffBroadcastInfo` in `AODVRouter` to calculate differences in connected users and broadcast only the changes.
* Added a periodic broadcast mechanism using `StartBroadcastTicker` to send differential updates at regular intervals.

### Packet Handling Updates:
* Updated `handleBroadcastInfo` in `AODVRouter` to process differential broadcast packets, including adding and removing users from the global user table (GUT).
* Modified `CreateRREPPacket` and related RREP handling logic to include a separate hop count for RREP packets, improving routing accuracy. [[1]](diffhunk://#diff-169cdcadf38c67ef0470dae90bb67ec37ff27d3b79b6f71c2ac7eaeb7611eb04L354-R354) [[2]](diffhunk://#diff-6e78a2520340a21609549abfddb4ab08f7277a13a9426530f7eb31e349c1b9d8L508-R552)

### Packet Structure Enhancements:
* Replaced `UERRUserID`, `UERRNodeID`, and `OriginNode` in `UERRHeader` with `UserID`, `NodeID`, and `OriginNodeID` for consistency. Updated related methods for serialization and deserialization. [[1]](diffhunk://#diff-169cdcadf38c67ef0470dae90bb67ec37ff27d3b79b6f71c2ac7eaeb7611eb04L89-R91) [[2]](diffhunk://#diff-169cdcadf38c67ef0470dae90bb67ec37ff27d3b79b6f71c2ac7eaeb7611eb04L808-R810) [[3]](diffhunk://#diff-169cdcadf38c67ef0470dae90bb67ec37ff27d3b79b6f71c2ac7eaeb7611eb04L841-R843)
* Increased `MAX_HOPS` from 3 to 5 in `internal/packet/packet.go` to allow for longer routing paths.

### Code Refactoring and Cleanup:
* Removed explicit acknowledgment logic (`HandleDataAck`) and simplified pending transaction tracking in `handleDataForward` and `handleUserMessage` to reduce network traffic. [[1]](diffhunk://#diff-6e78a2520340a21609549abfddb4ab08f7277a13a9426530f7eb31e349c1b9d8L283-R302) [[2]](diffhunk://#diff-6e78a2520340a21609549abfddb4ab08f7277a13a9426530f7eb31e349c1b9d8L711-R764)
* Introduced `lastUsersShadow` in `AODVRouter` to track the last known state of connected users for differential calculations.

These changes collectively enhance the efficiency of the mesh network by reducing unnecessary broadcasts, improving route management, and ensuring better scalability.