### PR TITLE
Sim update

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+          "name": "Debug batch with sim.yaml",
+          "type": "go",
+          "request": "launch",
+          "mode": "debug",
+          // Point at the folder containing your main.go
+          "program": "${workspaceFolder}/cmd/batch",
+          // The exact flags you’d pass to `go run`
+          "args": [
+            "-scenario",
+            "${workspaceFolder}/sim.yaml"
+          ],
+          // So that relative paths inside your app resolve correctly
+          "cwd": "${workspaceFolder}",
+          // Optional: see Delve logs in the Debug Console
+          "showLog": true
+        }
+      ]
+}

--- a/cmd/batch/main.go
+++ b/cmd/batch/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+    "flag"
+    "log"
+
+    eb "mesh-simulation/internal/eventBus"
+    "mesh-simulation/internal/metrics"
+    "mesh-simulation/internal/network"
+    "mesh-simulation/internal/sim"
+)
+
+func main() {
+    // 1. Pick scenario file or quick flags
+    cfg := flag.String("scenario", "scenario.yaml", "YAML or JSON scenario description")
+    flag.Parse()
+
+    sc, err := sim.LoadScenario(*cfg)
+    if err != nil { log.Fatalf("scenario: %v", err) }
+
+    bus := eb.NewEventBus()
+    net := network.NewNetwork(bus)
+
+	metrics.Global = metrics.NewCollector()
+
+    runner := sim.NewRunner(sc, bus, net, metrics.Global)
+    if err := runner.Run(); err != nil {
+        log.Fatalf("runner: %v", err)
+    }
+
+    if err := metrics.Global.Flush(sc.Logging.MetricsFile); err != nil {
+        log.Printf("flush‑metrics: %v", err)
+    }
+
+    log.Printf("run complete – stats written to %s", sc.Logging.MetricsFile)
+}

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,5 @@ require (
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	golang.org/x/net v0.27.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -12,3 +12,6 @@ golang.org/x/net v0.27.0 h1:5K3Njcw06/l2y9vpGCSdcxWOYHOUk3dVNGDXN+FvAys=
 golang.org/x/net v0.27.0/go.mod h1:dDi0PyhWNoiUOrAS8uXv/vnScO4wnHQO4mj9fn/RytE=
 golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
 golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/eventBus/eventBus.go
+++ b/internal/eventBus/eventBus.go
@@ -9,16 +9,18 @@ import (
 type EventType string
 
 const (
-	EventNodeJoined       EventType = "NODE_JOINED"
-	EventNodeLeft         EventType = "NODE_LEFT"
-	EventMessageSent      EventType = "MESSAGE_SENT"
-	EventMessageDelivered EventType = "MESSAGE_DELIVERED"
-	EventAddRouteEntry    EventType = "ADD_ROUTE_ENTRY"
-	EventMovedNode        EventType = "MOVED_NODE"
-	EventRemoveRouteEntry EventType = "REMOVED_ROUTE_ENTRY"
-	EventCreateUser       EventType = "CREATE_USER"
-	EventDeleteUser       EventType = "DELETE_USER"
-	EventUserMessage      EventType = "USER_MESSAGE"
+	EventNodeJoined              EventType = "NODE_JOINED"
+	EventNodeLeft                EventType = "NODE_LEFT"
+	EventMessageSent             EventType = "MESSAGE_SENT"
+	EventMessageDelivered        EventType = "MESSAGE_DELIVERED"
+	EventAddRouteEntry           EventType = "ADD_ROUTE_ENTRY"
+	EventMovedNode               EventType = "MOVED_NODE"
+	EventRemoveRouteEntry        EventType = "REMOVED_ROUTE_ENTRY"
+	EventCreateUser              EventType = "CREATE_USER"
+	EventDeleteUser              EventType = "DELETE_USER"
+	EventUserMessage             EventType = "USER_MESSAGE"
+	EventControlMessageDelivered EventType = "CONTROL_MESSAGE_DELIVERED"
+	EventControlMessageSent      EventType = "CONTROL_MESSAGE_SENT"
 )
 
 // RouteEntry represents an entry in the routing table.

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -1,58 +1,84 @@
 package metrics
 
 import (
-    "encoding/json"
-    "os"
-    "sync"
+	"encoding/json"
+	"os"
+	"sync"
 
-    eb "mesh-simulation/internal/eventBus"
+	eb "mesh-simulation/internal/eventBus"
 )
 
 type Counters struct {
-    TotalSent      uint64            `json:"total_sent"`
-    TotalDelivered uint64            `json:"total_delivered"`
-    Collisions     uint64            `json:"collisions"`
-    CollByType     map[uint8]uint64  `json:"collisions_by_type"`
-    HopSum         uint64            `json:"hop_sum"`
-    HopCount       uint64            `json:"hop_samples"`
+	TotalSent             uint64           `json:"total_sent"`
+	TotalControlSent      uint64           `json:"total_control_sent"`
+	TotalDelivered        uint64           `json:"total_delivered"`
+	TotalControlDelivered uint64           `json:"total_control_delivered"`
+	Collisions            uint64           `json:"collisions"`
+	CollByType            map[uint8]uint64 `json:"collisions_by_type"`
+	HopSum                uint64           `json:"hop_sum"`
+	HopCount              uint64           `json:"hop_samples"`
 }
 
 type Collector struct {
-    mu sync.Mutex
-    Counters
+	mu sync.Mutex
+	Counters
 }
 
 func NewCollector() *Collector {
-    return &Collector{Counters: Counters{CollByType: make(map[uint8]uint64)}}
+	return &Collector{Counters: Counters{CollByType: make(map[uint8]uint64)}}
 }
 
 func (c *Collector) AddCollision(pktType uint8) {
-	if c == nil { return }
-    c.mu.Lock(); defer c.mu.Unlock()
-    c.Collisions++
-    c.CollByType[pktType]++
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.Collisions++
+	c.CollByType[pktType]++
 }
 
 func (c *Collector) AddSent() {
-    c.mu.Lock(); c.TotalSent++; c.mu.Unlock()
+	c.mu.Lock()
+	c.TotalSent++
+	c.mu.Unlock()
+}
+
+func (c *Collector) AddControlSent() {
+	c.mu.Lock()
+	c.TotalControlSent++
+	c.mu.Unlock()
 }
 
 func (c *Collector) AddDelivered(ev eb.Event) {
-    c.mu.Lock()
-    c.TotalDelivered++
-    if ev.OtherNodeID != 0 {
-        c.HopSum += uint64(ev.OtherNodeID)
-        c.HopCount++
-    }
-    c.mu.Unlock()
+	c.mu.Lock()
+	c.TotalDelivered++
+	if ev.OtherNodeID != 0 {
+		c.HopSum += uint64(ev.OtherNodeID)
+		c.HopCount++
+	}
+	c.mu.Unlock()
+}
+
+func (c *Collector) AddControlDelivered(ev eb.Event) {
+	c.mu.Lock()
+	c.TotalControlDelivered++
+	// if ev.OtherNodeID != 0 {
+	//     c.HopSum += uint64(ev.OtherNodeID)
+	//     c.HopCount++
+	// }
+	c.mu.Unlock()
 }
 
 func (c *Collector) Flush(file string) error {
-    c.mu.Lock(); defer c.mu.Unlock()
-    f, err := os.Create(file)
-    if err != nil { return err }
-    defer f.Close()
-    enc := json.NewEncoder(f)
-    enc.SetIndent("", "  ")
-    return enc.Encode(c.Counters)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	f, err := os.Create(file)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	return enc.Encode(c.Counters)
 }

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -41,7 +41,7 @@ func (c *Collector) AddDelivered(ev eb.Event) {
     c.mu.Lock()
     c.TotalDelivered++
     if ev.OtherNodeID != 0 {
-        c.HopSum += uint64(ev.OtherNodeID) // here OtherNodeID is reused for hops in the example
+        c.HopSum += uint64(ev.OtherNodeID)
         c.HopCount++
     }
     c.mu.Unlock()

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -1,0 +1,58 @@
+package metrics
+
+import (
+    "encoding/json"
+    "os"
+    "sync"
+
+    eb "mesh-simulation/internal/eventBus"
+)
+
+type Counters struct {
+    TotalSent      uint64            `json:"total_sent"`
+    TotalDelivered uint64            `json:"total_delivered"`
+    Collisions     uint64            `json:"collisions"`
+    CollByType     map[uint8]uint64  `json:"collisions_by_type"`
+    HopSum         uint64            `json:"hop_sum"`
+    HopCount       uint64            `json:"hop_samples"`
+}
+
+type Collector struct {
+    mu sync.Mutex
+    Counters
+}
+
+func NewCollector() *Collector {
+    return &Collector{Counters: Counters{CollByType: make(map[uint8]uint64)}}
+}
+
+func (c *Collector) AddCollision(pktType uint8) {
+	if c == nil { return }
+    c.mu.Lock(); defer c.mu.Unlock()
+    c.Collisions++
+    c.CollByType[pktType]++
+}
+
+func (c *Collector) AddSent() {
+    c.mu.Lock(); c.TotalSent++; c.mu.Unlock()
+}
+
+func (c *Collector) AddDelivered(ev eb.Event) {
+    c.mu.Lock()
+    c.TotalDelivered++
+    if ev.OtherNodeID != 0 {
+        c.HopSum += uint64(ev.OtherNodeID) // here OtherNodeID is reused for hops in the example
+        c.HopCount++
+    }
+    c.mu.Unlock()
+}
+
+func (c *Collector) Flush(file string) error {
+    c.mu.Lock(); defer c.mu.Unlock()
+    f, err := os.Create(file)
+    if err != nil { return err }
+    defer f.Close()
+    enc := json.NewEncoder(f)
+    enc.SetIndent("", "  ")
+    return enc.Encode(c.Counters)
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,3 @@
+package metrics
+
+var Global = NewCollector()

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -94,7 +94,7 @@ func (n *nodeImpl) Run(net mesh.INetwork) {
 
 // SendData is a convenience method calling into the router
 func (n *nodeImpl) SendData(net mesh.INetwork, destID uint32, payload string) {
-	n.router.SendDataCSMA(net, n, destID, payload)
+	n.router.SendData(net, n, destID, payload)
 }
 
 // send user message

--- a/internal/routing/aodv.go
+++ b/internal/routing/aodv.go
@@ -1030,7 +1030,7 @@ func (r *AODVRouter) handleUREQ(net mesh.INetwork, node mesh.INode, receivedPack
 			Type: eventBus.EventControlMessageDelivered,
 		})
 		// reply with UREP along reverse path
-		log.Printf("[sim] [UREQ] Node %d: has ROUTE userr %d (hop count %d)\n", r.ownerID, uh.UREQUserID, bh.HopCount)
+		log.Printf("[sim] [UREQ] Node %d: has ROUTE userr %d (hop count %d)\n", r.ownerID, uh.UREQUserID, bh.HopCount+1)
 		reply, pid, _ := packet.CreateUREPPacket(r.ownerID, bh.SrcNodeID, uh.OriginNodeID, n.NodeID, uh.UREQUserID, 0, 0)
 		// r.BroadcastMessageCSMA(net, node, reply, pid)
 		r.txQueue <- outgoingTx{net: net, sender: node, pkt: reply, pktID: pid}
@@ -1045,7 +1045,7 @@ func (r *AODVRouter) handleUREQ(net mesh.INetwork, node mesh.INode, receivedPack
 	if err != nil {
 		return
 	}
-	log.Printf("[sim] [UREQ FORWARD] Node %d: forwarding UREQ for %d (hop count %d)\n", r.ownerID, uh.UREQUserID, bh.HopCount)
+	log.Printf("[sim] [UREQ FORWARD] Node %d: forwarding UREQ for %d (hop count %d)\n", r.ownerID, uh.UREQUserID, bh.HopCount+1)
 	// net.BroadcastMessage(fwdMsg, node)
 	// r.BroadcastMessageCSMA(net, node, fwdUREQ, packetId)
 	r.txQueue <- outgoingTx{net: net, sender: node, pkt: fwdUREQ, pktID: packetID}

--- a/internal/routing/aodv.go
+++ b/internal/routing/aodv.go
@@ -743,6 +743,11 @@ func (r *AODVRouter) handleDataForward(net mesh.INetwork, node mesh.INode, recei
 		return
 	}
 
+	if r.seenMsgIDs[bh.PacketID] {
+		return
+	}
+	r.seenMsgIDs[bh.PacketID] = true
+
 	payloadString := string(payload)
 	// If I'm the final destination, do nothing -> the node can "deliver" it
 	if dh.FinalDestID == r.ownerID {
@@ -820,6 +825,11 @@ func (r *AODVRouter) handleUserMessage(net mesh.INetwork, node mesh.INode, recei
 		return
 	}
 
+	if r.seenMsgIDs[bh.PacketID] {
+		return
+	}
+	r.seenMsgIDs[bh.PacketID] = true
+
 	payloadString := string(payload)
 	if umh.ToNodeID == r.ownerID {
 		// check that the user is at this node
@@ -887,11 +897,16 @@ func (r *AODVRouter) handleUserMessage(net mesh.INetwork, node mesh.INode, recei
 // Handle Data ACKs, should remove from pendingTxs
 func (r *AODVRouter) HandleDataAck(receivedPacket []byte) {
 	// Unpack the payload and remove from pendingTxs
-	_, ack, err := packet.DeserialiseACKPacket(receivedPacket)
+	bh, ack, err := packet.DeserialiseACKPacket(receivedPacket)
 
 	if err != nil {
 		return
 	}
+
+	if r.seenMsgIDs[bh.PacketID] {
+		return
+	}
+	r.seenMsgIDs[bh.PacketID] = true
 
 	// log.Printf("{ACK} Node %d: received ACK for msgID=%d\n", r.ownerID, ack.MsgID)
 

--- a/internal/routing/aodv.go
+++ b/internal/routing/aodv.go
@@ -194,14 +194,18 @@ func (r *AODVRouter) SendData(net mesh.INetwork, sender mesh.INode, destID uint3
 	log.Printf("[sim] Node %d (router) -> forwarding data to %d via %d\n", r.ownerID, destID, nextHop)
 	net.BroadcastMessage(completePacket, sender, packetID)
 
-	expire := time.Now().Add(10 * time.Second) // e.g. 3s
-	r.pendingTxs[packetID] = PendingTx{
-		MsgID:               packetID,
-		Dest:                destID,
-		PotentialBrokenNode: nextHop,
-		Origin:              r.ownerID,
-		ExpiryTime:          expire,
+	if destID != nextHop {
+		expire := time.Now().Add(10 * time.Second) // e.g. 3s
+		r.pendingTxs[packetID] = PendingTx{
+			MsgID:               packetID,
+			Dest:                destID,
+			PotentialBrokenNode: nextHop,
+			Origin:              r.ownerID,
+			ExpiryTime:          expire,
+		}
+
 	}
+
 }
 
 func (r *AODVRouter) SendUserMessage(net mesh.INetwork, sender mesh.INode, sendUserID, destUserID uint32, payload string) {
@@ -240,13 +244,16 @@ func (r *AODVRouter) SendUserMessage(net mesh.INetwork, sender mesh.INode, sendU
 	log.Printf("[sim] Node %d (router) -> forwarding user message to %d via %d\n", r.ownerID, userEntry.NodeID, nextHop)
 	net.BroadcastMessage(completePacket, sender, packetID)
 
-	expire := time.Now().Add(10 * time.Second) // e.g. 3s
-	r.pendingTxs[packetID] = PendingTx{
-		MsgID:               packetID,
-		Dest:                userEntry.NodeID,
-		PotentialBrokenNode: nextHop,
-		Origin:              r.ownerID,
-		ExpiryTime:          expire,
+	if userEntry.NodeID != nextHop {
+		expire := time.Now().Add(10 * time.Second) // e.g. 3s
+		r.pendingTxs[packetID] = PendingTx{
+			MsgID:               packetID,
+			Dest:                userEntry.NodeID,
+			PotentialBrokenNode: nextHop,
+			Origin:              r.ownerID,
+			ExpiryTime:          expire,
+		}
+
 	}
 
 }

--- a/internal/routing/router_interface.go
+++ b/internal/routing/router_interface.go
@@ -9,7 +9,7 @@ type IRouter interface {
 	// Called by the node to send data to destID
 	SendData(net mesh.INetwork, sender mesh.INode, destID uint32, payload string)
 	// Called by the node to send data to destID using CSMA
-	SendDataCSMA(net mesh.INetwork, sender mesh.INode, destID uint32, payload string)
+	// SendDataCSMA(net mesh.INetwork, sender mesh.INode, destID uint32, payload string)
 	// Called by the node when it receives *any* message, so the router can process RREQ, RREP, or forward data
 	HandleMessage(net mesh.INetwork, node mesh.INode, msg []byte)
 

--- a/internal/sim/runner.go
+++ b/internal/sim/runner.go
@@ -34,7 +34,6 @@ func (r *Runner) Run() error {
 	// go func() { defer r.wg.Done(); r.net.Run() }()
 	go r.net.Run()
 
-
 	// ── build nodes & users ────────────────────────────────────────────────
 	// for i := 0; i < r.sc.Nodes.Count; i++ {
 	// 	lat := rand.Float64() * r.sc.AreaKm2
@@ -91,7 +90,7 @@ func (r *Runner) Run() error {
 			if leaver, ok := r.net.(interface{ LeaveAll() }); ok {
 				leaver.LeaveAll()
 			}
-			
+
 			r.wg.Wait()
 			return nil
 		case <-tick.C:
@@ -106,6 +105,10 @@ func (r *Runner) consumeEvents(ch chan eb.Event) {
 		case eb.EventMessageSent:
 			r.coll.AddSent()
 		case eb.EventMessageDelivered:
+			r.coll.AddDelivered(ev)
+		case eb.EventControlMessageSent:
+			r.coll.AddSent()
+		case eb.EventControlMessageDelivered:
 			r.coll.AddDelivered(ev)
 		}
 	}
@@ -144,7 +147,7 @@ func (r *Runner) emitRandomTraffic() {
 	case "BROADCAST":
 		from.SendBroadcastInfo(r.net)
 	}
-	r.coll.AddSent()
+	// r.coll.AddSent()
 }
 
 func choosePacket(m map[string]float64) string {

--- a/internal/sim/runner.go
+++ b/internal/sim/runner.go
@@ -1,0 +1,160 @@
+package sim
+
+import (
+	"math"
+	"math/rand"
+	"sync"
+	"time"
+
+	eb "mesh-simulation/internal/eventBus"
+	"mesh-simulation/internal/mesh"
+	"mesh-simulation/internal/metrics"
+	"mesh-simulation/internal/network"
+	"mesh-simulation/internal/node"
+)
+
+type Runner struct {
+	sc   *Scenario
+	bus  *eb.EventBus
+	net  mesh.INetwork
+	coll *metrics.Collector
+
+	wg   sync.WaitGroup
+	quit chan struct{}
+}
+
+func NewRunner(sc *Scenario, bus *eb.EventBus, net mesh.INetwork, coll *metrics.Collector) *Runner {
+	return &Runner{sc: sc, bus: bus, net: net, coll: coll, quit: make(chan struct{})}
+}
+
+func (r *Runner) Run() error {
+	rand.Seed(r.sc.Seed)
+	// start network goroutine
+	// r.wg.Add(1)
+	// go func() { defer r.wg.Done(); r.net.Run() }()
+	go r.net.Run()
+
+
+	// ── build nodes & users ────────────────────────────────────────────────
+	// for i := 0; i < r.sc.Nodes.Count; i++ {
+	// 	lat := rand.Float64() * r.sc.AreaKm2
+	// 	lng := rand.Float64() * r.sc.AreaKm2
+	// 	n := node.NewNode(lat, lng, r.bus)
+	// 	r.net.Join(n)
+	// 	// attach users
+	// 	for u := 0; u < r.sc.Users.PerNode; u++ {
+	// 		id := uint32(rand.Int31())
+	// 		n.AddConnectedUser(id)
+	// 	}
+	// 	r.wg.Add(1)
+	// 	go func(nd mesh.INode) { defer r.wg.Done(); nd.Run(r.net) }(n)
+	// }
+
+	// ── build nodes & users (grid) ──────────────────────────────
+	rows := int(math.Ceil(math.Sqrt(float64(r.sc.Nodes.Count))))
+	cols := rows
+	side := math.Sqrt(r.sc.AreaKm2) // side length of square
+
+	idx := 0
+	for rRow := 0; rRow < rows && idx < r.sc.Nodes.Count; rRow++ {
+		for cCol := 0; cCol < cols && idx < r.sc.Nodes.Count; cCol++ {
+			lat := float64(rRow) * side / float64(rows-1)
+			lng := float64(cCol) * side / float64(cols-1)
+			n := node.NewNode(lat, lng, r.bus)
+			r.net.Join(n)
+			for u := 0; u < r.sc.Users.PerNode; u++ {
+				n.AddConnectedUser(uint32(rand.Int31()))
+			}
+			idx++
+		}
+	}
+
+	// ── metrics wire‑up ────────────────────────────────────────────────────
+	sub := r.bus.Subscribe()
+	go r.consumeEvents(sub)
+
+	// ── traffic generator ─────────────────────────────────────────────────
+	λ := r.sc.Traffic.MsgPerNodePerMin / 60.0 // per‑sec rate per node
+	if λ == 0 {
+		λ = 0.1
+	}
+	interval := time.Duration(1e9 / (λ * float64(r.sc.Nodes.Count))) // ns
+	tick := time.NewTicker(interval)
+	defer tick.Stop()
+
+	done := time.After(r.sc.Duration)
+
+	for {
+		select {
+		case <-done:
+			close(r.quit)
+			if leaver, ok := r.net.(interface{ LeaveAll() }); ok {
+				leaver.LeaveAll()
+			}
+			
+			r.wg.Wait()
+			return nil
+		case <-tick.C:
+			r.emitRandomTraffic()
+		}
+	}
+}
+
+func (r *Runner) consumeEvents(ch chan eb.Event) {
+	for ev := range ch {
+		switch ev.Type {
+		case eb.EventMessageSent:
+			r.coll.AddSent()
+		case eb.EventMessageDelivered:
+			r.coll.AddDelivered(ev)
+		}
+	}
+}
+
+func (r *Runner) emitRandomTraffic() {
+	nodeMap := r.net.(*network.NetworkImpl).Nodes
+	if len(nodeMap) < 2 {
+		return
+	}
+	keys := make([]mesh.INode, 0, len(nodeMap))
+	for _, n := range nodeMap {
+		keys = append(keys, n)
+	}
+
+	from := keys[rand.Intn(len(keys))]
+	to := keys[rand.Intn(len(keys))]
+	if from.GetID() == to.GetID() {
+		return
+	}
+
+	// pick packet type according to mix
+	pt := choosePacket(r.sc.Traffic.PacketMix)
+	switch pt {
+	case "DATA":
+		from.SendData(r.net, to.GetID(), "hello")
+	case "USER_MSG":
+		users := to.GetConnectedUsers()
+		if len(users) == 0 {
+			return
+		}
+		du := users[rand.Intn(len(users))]
+		su := uint32(rand.Int31())
+		from.AddConnectedUser(su)
+		from.SendUserMessage(r.net, su, du, "ping")
+	case "BROADCAST":
+		from.SendBroadcastInfo(r.net)
+	}
+	r.coll.AddSent()
+}
+
+func choosePacket(m map[string]float64) string {
+	p := rand.Float64()
+	acc := 0.0
+	for k, v := range m {
+		acc += v
+		if p <= acc {
+			return k
+		}
+	}
+	return "DATA"
+}

--- a/internal/sim/scenario.go
+++ b/internal/sim/scenario.go
@@ -1,0 +1,57 @@
+package sim
+
+import (
+    "encoding/json"
+    "os"
+    "time"
+
+    "gopkg.in/yaml.v3"
+)
+
+type NodeCfg struct {
+    Count     int     `yaml:"count" json:"count"`
+    Placement string  `yaml:"placement" json:"placement"` // uniform | grid | hotspot
+}
+
+type UserCfg struct {
+    PerNode int `yaml:"per_node" json:"per_node"`
+}
+
+type TrafficCfg struct {
+    Pattern           string             `yaml:"pattern" json:"pattern"`
+    MsgPerNodePerMin  float64            `yaml:"msg_per_node_per_min" json:"msg_per_node_per_min"`
+    PacketMix         map[string]float64 `yaml:"packet_mix" json:"packet_mix"`
+}
+
+type RoutingCfg struct {
+    MaxHops int `yaml:"max_hops" json:"max_hops"`
+}
+
+type LogCfg struct {
+    MetricsFile string `yaml:"metrics_file" json:"metrics_file"`
+}
+
+type Scenario struct {
+    Duration time.Duration `yaml:"duration" json:"duration"`
+    Seed     int64         `yaml:"seed" json:"seed"`
+    AreaKm2  float64       `yaml:"area_km2" json:"area_km2"`
+    Nodes    NodeCfg       `yaml:"nodes" json:"nodes"`
+    Users    UserCfg       `yaml:"users" json:"users"`
+    Traffic  TrafficCfg    `yaml:"traffic" json:"traffic"`
+    Routing  RoutingCfg    `yaml:"routing" json:"routing"`
+    Logging  LogCfg        `yaml:"logging" json:"logging"`
+}
+
+func LoadScenario(path string) (*Scenario, error) {
+    f, err := os.ReadFile(path)
+    if err != nil { return nil, err }
+    sc := &Scenario{}
+    if yaml.Unmarshal(f, sc) == nil {
+        return sc, nil
+    }
+    // fallback JSON
+    if err := json.Unmarshal(f, sc); err != nil {
+        return nil, err
+    }
+    return sc, nil
+}

--- a/internal/sim/scenario.go
+++ b/internal/sim/scenario.go
@@ -1,57 +1,61 @@
 package sim
 
 import (
-    "encoding/json"
-    "os"
-    "time"
+	"encoding/json"
+	"os"
+	"time"
 
-    "gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 type NodeCfg struct {
-    Count     int     `yaml:"count" json:"count"`
-    Placement string  `yaml:"placement" json:"placement"` // uniform | grid | hotspot
+	Count     int           `yaml:"count" json:"count"`
+	Placement string        `yaml:"placement" json:"placement"` // uniform | grid | hotspot
+	JoinDelay time.Duration `yaml:"join_delay" json:"join_delay"`
 }
 
 type UserCfg struct {
-    PerNode int `yaml:"per_node" json:"per_node"`
+	PerNode int `yaml:"per_node" json:"per_node"`
 }
 
 type TrafficCfg struct {
-    Pattern           string             `yaml:"pattern" json:"pattern"`
-    MsgPerNodePerMin  float64            `yaml:"msg_per_node_per_min" json:"msg_per_node_per_min"`
-    PacketMix         map[string]float64 `yaml:"packet_mix" json:"packet_mix"`
+	Pattern          string             `yaml:"pattern" json:"pattern"`
+	MsgPerNodePerMin float64            `yaml:"msg_per_node_per_min" json:"msg_per_node_per_min"`
+	PacketMix        map[string]float64 `yaml:"packet_mix" json:"packet_mix"`
 }
 
 type RoutingCfg struct {
-    MaxHops int `yaml:"max_hops" json:"max_hops"`
+	MaxHops int `yaml:"max_hops" json:"max_hops"`
 }
 
 type LogCfg struct {
-    MetricsFile string `yaml:"metrics_file" json:"metrics_file"`
+	MetricsFile string `yaml:"metrics_file" json:"metrics_file"`
 }
 
 type Scenario struct {
-    Duration time.Duration `yaml:"duration" json:"duration"`
-    Seed     int64         `yaml:"seed" json:"seed"`
-    AreaKm2  float64       `yaml:"area_km2" json:"area_km2"`
-    Nodes    NodeCfg       `yaml:"nodes" json:"nodes"`
-    Users    UserCfg       `yaml:"users" json:"users"`
-    Traffic  TrafficCfg    `yaml:"traffic" json:"traffic"`
-    Routing  RoutingCfg    `yaml:"routing" json:"routing"`
-    Logging  LogCfg        `yaml:"logging" json:"logging"`
+	Duration     time.Duration `yaml:"duration" json:"duration"`
+	Seed         int64         `yaml:"seed" json:"seed"`
+	AreaKm2      float64       `yaml:"area_km2" json:"area_km2"`
+	Nodes        NodeCfg       `yaml:"nodes" json:"nodes"`
+	Users        UserCfg       `yaml:"users" json:"users"`
+	StartupDelay time.Duration `yaml:"startup_delay" json:"startup_delay"`
+	Traffic      TrafficCfg    `yaml:"traffic" json:"traffic"`
+	Routing      RoutingCfg    `yaml:"routing" json:"routing"`
+	Logging      LogCfg        `yaml:"logging" json:"logging"`
 }
 
 func LoadScenario(path string) (*Scenario, error) {
-    f, err := os.ReadFile(path)
-    if err != nil { return nil, err }
-    sc := &Scenario{}
-    if yaml.Unmarshal(f, sc) == nil {
-        return sc, nil
-    }
-    // fallback JSON
-    if err := json.Unmarshal(f, sc); err != nil {
-        return nil, err
-    }
-    return sc, nil
+	f, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	sc := &Scenario{}
+	if yaml.Unmarshal(f, sc) == nil {
+		return sc, nil
+	}
+	// fallback JSON
+	if err := json.Unmarshal(f, sc); err != nil {
+		return nil, err
+	}
+	return sc, nil
 }

--- a/sim.yaml
+++ b/sim.yaml
@@ -1,5 +1,5 @@
 # Duration of the simulation
-duration: 30s
+duration: 90s
 
 # Random seed for deterministic runs
 seed: 12345
@@ -8,7 +8,7 @@ seed: 12345
 area_km2: 5.0
 
 nodes:
-  count: 7            # number of virtual nodes in the mesh
+  count: 25             # number of virtual nodes in the mesh
   placement: uniform   # uniform | grid | hotspot -> only GRID is supported
 
 users:
@@ -16,7 +16,7 @@ users:
 
 traffic:
   pattern: poisson     # poisson | burst | custom
-  msg_per_node_per_min: 10
+  msg_per_node_per_min: 20
   packet_mix:
     DATA:      0.5
     USER_MSG:  0.5

--- a/sim.yaml
+++ b/sim.yaml
@@ -1,18 +1,22 @@
 # Duration of the simulation
-duration: 90s
+duration: 0s
 
 # Random seed for deterministic runs
 seed: 12345
 
 # Square area side length in "units" (e.g. km)
-area_km2: 5.0
+area_km2: 3.0
 
 nodes:
-  count: 25             # number of virtual nodes in the mesh
+  count: 10             # number of virtual nodes in the mesh
   placement: uniform   # uniform | grid | hotspot -> only GRID is supported
+  join_delay: 3000ms    # delay between node joins
 
 users:
   per_node: 2          # attach 2 simulated users per node
+
+# Delay after all nodes have joined before starting traffic
+startup_delay: 30s
 
 traffic:
   pattern: poisson     # poisson | burst | custom

--- a/sim.yaml
+++ b/sim.yaml
@@ -1,0 +1,29 @@
+# Duration of the simulation
+duration: 30s
+
+# Random seed for deterministic runs
+seed: 12345
+
+# Square area side length in "units" (e.g. km)
+area_km2: 5.0
+
+nodes:
+  count: 7            # number of virtual nodes in the mesh
+  placement: uniform   # uniform | grid | hotspot -> only GRID is supported
+
+users:
+  per_node: 2          # attach 2 simulated users per node
+
+traffic:
+  pattern: poisson     # poisson | burst | custom
+  msg_per_node_per_min: 10
+  packet_mix:
+    DATA:      0.5
+    USER_MSG:  0.5
+    BROADCAST: 0
+
+routing:
+  max_hops: 5          # override packet.MAX_HOPS
+
+logging:
+  metrics_file: "logs/metrics_{{timestamp}}.json"


### PR DESCRIPTION
This pull request introduces significant updates to the mesh simulation project, including the addition of debugging support, a new metrics collection system, expanded event handling, and refactoring of the network implementation. These changes enhance the functionality, observability, and maintainability of the codebase.

### Debugging and Configuration
* Added a new debugging configuration in `.vscode/launch.json` to enable debugging of the `batch` command with a `sim.yaml` scenario file.

### Metrics Collection
* Introduced a `Collector` struct in `internal/metrics/collector.go` to track and log metrics such as sent messages, delivered messages, collisions, and hops. Metrics can be flushed to a file in JSON format.
* Added a global metrics collector in `internal/metrics/metrics.go` to provide a singleton instance for metrics tracking.

### Event Handling Enhancements
* Added new event types `CONTROL_MESSAGE_SENT` and `CONTROL_MESSAGE_DELIVERED` in `internal/eventBus/eventBus.go` to track control message events.
* Updated the `physicalNode` implementation to handle MQTT commands for adding/removing users and updating routes, with corresponding events published to the event bus.

### Network Refactoring
* Refactored `networkImpl` to `NetworkImpl` in `internal/network/network.go`, making fields like `Nodes` public for better accessibility and enabling collision tracking integrated with the metrics collector. [[1]](diffhunk://#diff-0fc7f3150d0356714176307e25ee100b23f9b2060c2650a7ac5d94bac8827539L45-R48) [[2]](diffhunk://#diff-0fc7f3150d0356714176307e25ee100b23f9b2060c2650a7ac5d94bac8827539R150-R151)
* Updated network methods (e.g., `Join`, `Leave`, `BroadcastMessage`) to reflect the refactored structure and integrate collision detection. [[1]](diffhunk://#diff-0fc7f3150d0356714176307e25ee100b23f9b2060c2650a7ac5d94bac8827539L75-R76) [[2]](diffhunk://#diff-0fc7f3150d0356714176307e25ee100b23f9b2060c2650a7ac5d94bac8827539L173-R203)

### Routing Improvements
* Introduced synchronization mechanisms (`sync.RWMutex`) in the AODV router to ensure thread-safe access to routing tables and seen message IDs.
* Added a new `outgoingTx` struct in `internal/routing/aodv.go` to manage outgoing transmissions.